### PR TITLE
fix: add missing autoprefixer dependency for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "autoprefixer": "^10.4.20",
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
     "postcss": "^8",


### PR DESCRIPTION
Fixes #4

Adds the missing `autoprefixer` dependency that was causing Vercel builds to fail. The PostCSS configuration references autoprefixer, but it wasn't installed in package.json.

### Changes
- Added `autoprefixer: "^10.4.20"` to devDependencies

Generated with [Claude Code](https://claude.ai/code)