### PR TITLE
feat: Replace Getting Started with GitHub issue creator

### DIFF
--- a/app/api/github/issues/route.ts
+++ b/app/api/github/issues/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { getAuth } from '@/lib/auth'
+
+export async function POST(request: Request) {
+  try {
+    const session = await getAuth()
+
+    if (!session || !session.accessToken) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { owner, repo, title, body } = await request.json()
+
+    if (!owner || !repo || !title) {
+      return NextResponse.json(
+        { error: 'Missing required fields: owner, repo, title' },
+        { status: 400 }
+      )
+    }
+
+    // Create the issue
+    const issueResponse = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title, body }),
+      }
+    )
+
+    if (!issueResponse.ok) {
+      const errorData = await issueResponse.json()
+      throw new Error(errorData.message || 'Failed to create issue')
+    }
+
+    const issue = await issueResponse.json()
+
+    // Add the automated comment
+    const commentResponse = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/issues/${issue.number}/comments`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github.v3+json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          body: '@claude please implement end to end and create PR',
+        }),
+      }
+    )
+
+    if (!commentResponse.ok) {
+      console.error('Failed to add comment to issue')
+    }
+
+    return NextResponse.json(issue)
+  } catch (error) {
+    console.error('Error creating issue:', error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to create issue' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { getAuth } from '@/lib/auth'
+
+export async function GET() {
+  try {
+    const session = await getAuth()
+
+    if (!session || !session.accessToken) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const response = await fetch(
+      'https://api.github.com/user/repos?sort=updated&per_page=100',
+      {
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch repositories')
+    }
+
+    const repos = await response.json()
+
+    return NextResponse.json(repos)
+  } catch (error) {
+    console.error('Error fetching repositories:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch repositories' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button"
 import { LogOut, User, Mail, Calendar } from "lucide-react"
 import SignOutButton from "@/components/sign-out-button"
+import { GitHubIssueCreator } from "@/components/github-issue-creator"
 
 export default async function DashboardPage() {
   const session = await getAuth()
@@ -119,59 +120,9 @@ export default async function DashboardPage() {
           </Card>
         </div>
 
-        <Card className="mt-6 border-gray-200 dark:border-gray-700">
-          <CardHeader>
-            <CardTitle>Getting Started</CardTitle>
-            <CardDescription>
-              Explore the features of your dashboard
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-black dark:bg-white flex items-center justify-center flex-shrink-0">
-                  <span className="text-white dark:text-black font-bold text-sm">1</span>
-                </div>
-                <div>
-                  <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
-                    Your Profile is Set Up
-                  </h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Your GitHub account is successfully connected and authenticated.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center flex-shrink-0">
-                  <span className="text-gray-700 dark:text-gray-300 font-bold text-sm">2</span>
-                </div>
-                <div>
-                  <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
-                    Explore the Dashboard
-                  </h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Take a look around and familiarize yourself with the interface.
-                  </p>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-3">
-                <div className="w-8 h-8 rounded-full bg-gray-300 dark:bg-gray-600 flex items-center justify-center flex-shrink-0">
-                  <span className="text-gray-700 dark:text-gray-300 font-bold text-sm">3</span>
-                </div>
-                <div>
-                  <h3 className="font-semibold text-gray-900 dark:text-white mb-1">
-                    Customize Your Experience
-                  </h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Add more features and personalize your dashboard.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <div className="mt-6">
+          <GitHubIssueCreator />
+        </div>
       </main>
     </div>
   )

--- a/components/github-issue-creator.tsx
+++ b/components/github-issue-creator.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import * as React from 'react'
+import { Check, ChevronsUpDown, Github, Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+
+interface Repository {
+  id: number
+  name: string
+  full_name: string
+  description: string | null
+  owner: {
+    login: string
+  }
+}
+
+export function GitHubIssueCreator() {
+  const [open, setOpen] = React.useState(false)
+  const [selectedRepo, setSelectedRepo] = React.useState<Repository | null>(null)
+  const [repos, setRepos] = React.useState<Repository[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [issueTitle, setIssueTitle] = React.useState('')
+  const [issueBody, setIssueBody] = React.useState('')
+  const [creating, setCreating] = React.useState(false)
+  const [success, setSuccess] = React.useState<{ url: string; number: number } | null>(null)
+
+  React.useEffect(() => {
+    async function fetchRepos() {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await fetch('/api/github/repos')
+        if (!response.ok) {
+          throw new Error('Failed to fetch repositories')
+        }
+        const data = await response.json()
+        setRepos(data)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load repositories')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchRepos()
+  }, [])
+
+  const handleCreateIssue = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!selectedRepo || !issueTitle.trim()) {
+      return
+    }
+
+    setCreating(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const response = await fetch('/api/github/issues', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          owner: selectedRepo.owner.login,
+          repo: selectedRepo.name,
+          title: issueTitle,
+          body: issueBody,
+        }),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || 'Failed to create issue')
+      }
+
+      const issue = await response.json()
+      setSuccess({ url: issue.html_url, number: issue.number })
+      setIssueTitle('')
+      setIssueBody('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create issue')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <Card className="border-gray-200 dark:border-gray-700">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Github className="h-5 w-5" />
+          Create GitHub Issue
+        </CardTitle>
+        <CardDescription>
+          Select a repository and create a new issue with automated Claude assistance
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {success && (
+          <Alert>
+            <AlertTitle>Issue Created Successfully!</AlertTitle>
+            <AlertDescription>
+              <a
+                href={success.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary underline hover:no-underline"
+              >
+                View Issue #{success.number}
+              </a>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="repository">Repository</Label>
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                id="repository"
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                className="w-full justify-between"
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Loading repositories...
+                  </>
+                ) : selectedRepo ? (
+                  selectedRepo.full_name
+                ) : (
+                  'Select repository...'
+                )}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search repositories..." />
+                <CommandList>
+                  <CommandEmpty>No repository found.</CommandEmpty>
+                  <CommandGroup>
+                    {repos.map((repo) => (
+                      <CommandItem
+                        key={repo.id}
+                        value={repo.full_name}
+                        onSelect={() => {
+                          setSelectedRepo(repo)
+                          setOpen(false)
+                          setSuccess(null)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            selectedRepo?.id === repo.id ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        <div className="flex flex-col">
+                          <span className="font-medium">{repo.full_name}</span>
+                          {repo.description && (
+                            <span className="text-xs text-muted-foreground line-clamp-1">
+                              {repo.description}
+                            </span>
+                          )}
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        {selectedRepo && (
+          <form onSubmit={handleCreateIssue} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="title">Issue Title</Label>
+              <Input
+                id="title"
+                placeholder="Enter issue title..."
+                value={issueTitle}
+                onChange={(e) => setIssueTitle(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description (optional)</Label>
+              <Textarea
+                id="description"
+                placeholder="Describe the issue..."
+                value={issueBody}
+                onChange={(e) => setIssueBody(e.target.value)}
+                rows={6}
+              />
+            </div>
+
+            <Button type="submit" disabled={creating || !issueTitle.trim()}>
+              {creating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating Issue...
+                </>
+              ) : (
+                'Create Issue'
+              )}
+            </Button>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,16 +7,28 @@ export const authOptions: NextAuthOptions = {
     GithubProvider({
       clientId: process.env.GITHUB_ID as string,
       clientSecret: process.env.GITHUB_SECRET as string,
+      authorization: {
+        params: {
+          scope: 'read:user user:email repo',
+        },
+      },
     }),
   ],
   pages: {
     signIn: '/login',
   },
   callbacks: {
+    async jwt({ token, account }) {
+      if (account) {
+        token.accessToken = account.access_token
+      }
+      return token
+    },
     async session({ session, token }) {
       if (session.user) {
         session.user.id = token.sub as string
       }
+      session.accessToken = token.accessToken as string
       return session
     },
   },

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -8,5 +8,12 @@ declare module "next-auth" {
       email?: string | null
       image?: string | null
     }
+    accessToken?: string
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string
   }
 }


### PR DESCRIPTION
This PR implements issue #6 by replacing the Getting Started section with an interactive GitHub issue creator built entirely with shadcn/ui components.

### Changes
- Add searchable repository dropdown using Command + Popover pattern
- Implement issue creation form with proper shadcn/ui components
- Add automated `@claude` comment on new issues
- Update NextAuth config to request 'repo' scope for GitHub API
- Create API routes for fetching repos and creating issues
- Use Alert, Button, Card, Input, Label, Textarea from components/ui
- Include comprehensive error handling and loading states
- Replace static Getting Started section with interactive component

Closes #6

Generated with [Claude Code](https://claude.ai/code)