### PR TITLE
fix: improve error handling for GitHub API routes

### DIFF
--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -5,9 +5,18 @@ export async function GET() {
   try {
     const session = await getAuth()
 
-    if (!session || !session.accessToken) {
+    if (!session) {
+      console.error('No session found - user needs to sign in')
       return NextResponse.json(
-        { error: 'Unauthorized' },
+        { error: 'Not authenticated. Please sign in to continue.' },
+        { status: 401 }
+      )
+    }
+
+    if (!session.accessToken) {
+      console.error('No access token in session - OAuth may not be configured correctly')
+      return NextResponse.json(
+        { error: 'Authentication token not found. Please sign out and sign in again.' },
         { status: 401 }
       )
     }
@@ -23,7 +32,31 @@ export async function GET() {
     )
 
     if (!response.ok) {
-      throw new Error('Failed to fetch repositories')
+      const errorBody = await response.text()
+      console.error('GitHub API error:', {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorBody,
+      })
+
+      if (response.status === 401) {
+        return NextResponse.json(
+          { error: 'GitHub authentication failed. Your token may have expired. Please sign out and sign in again.' },
+          { status: 401 }
+        )
+      }
+
+      if (response.status === 403) {
+        return NextResponse.json(
+          { error: 'Access forbidden. Please check that the GitHub App has the required "repo" permissions.' },
+          { status: 403 }
+        )
+      }
+
+      return NextResponse.json(
+        { error: `GitHub API error: ${response.statusText}` },
+        { status: response.status }
+      )
     }
 
     const repos = await response.json()
@@ -31,8 +64,9 @@ export async function GET() {
     return NextResponse.json(repos)
   } catch (error) {
     console.error('Error fetching repositories:', error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     return NextResponse.json(
-      { error: 'Failed to fetch repositories' },
+      { error: `Failed to fetch repositories: ${errorMessage}` },
       { status: 500 }
     )
   }


### PR DESCRIPTION
## Summary

Fixed the "Failed to fetch repositories" error by implementing comprehensive error handling in GitHub API routes. The generic error messages have been replaced with specific, actionable error messages that help users identify and resolve authentication and permission issues.

## Changes

- Enhanced error handling in `app/api/github/repos/route.ts` and `app/api/github/issues/route.ts`
- Split session and access token validation with specific error messages
- Added detailed console logging for GitHub API errors
- Return specific error messages for 401 (auth failure) and 403 (permission denied)
- Include GitHub API error details in error responses

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)