### PR TITLE
fix: use correct NextAuth config with repo scope

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,24 +1,6 @@
 import NextAuth from "next-auth"
-import GithubProvider from "next-auth/providers/github"
+import { authOptions } from "@/lib/auth"
 
-const handler = NextAuth({
-  providers: [
-    GithubProvider({
-      clientId: process.env.GITHUB_ID as string,
-      clientSecret: process.env.GITHUB_SECRET as string,
-    }),
-  ],
-  pages: {
-    signIn: '/login',
-  },
-  callbacks: {
-    async session({ session, token }) {
-      if (session.user) {
-        session.user.id = token.sub as string
-      }
-      return session
-    },
-  },
-})
+const handler = NextAuth(authOptions)
 
 export { handler as GET, handler as POST }


### PR DESCRIPTION
## Summary

Fixed the persistent "Failed to fetch repositories" error by consolidating NextAuth configurations. The NextAuth route handler was using an incomplete configuration that was missing the 'repo' OAuth scope and access token handling.

## Changes

- Updated `app/api/auth/[...nextauth]/route.ts` to use `authOptions` from `lib/auth.ts`
- This ensures OAuth tokens include the 'repo' scope needed to read repositories
- Removed duplicate configuration code

## Testing

After deploying this fix:
1. Sign out of the application
2. Sign back in with GitHub
3. The new OAuth flow will request repo permissions
4. Repository fetching should now work

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)