### PR TITLE
Add theme switcher toggle in header

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { LogOut, User, Mail, Calendar } from "lucide-react"
 import SignOutButton from "@/components/sign-out-button"
 import { GitHubIssueCreator } from "@/components/github-issue-creator"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export default async function DashboardPage() {
   const session = await getAuth()
@@ -41,7 +42,10 @@ export default async function DashboardPage() {
                 ACME Corp
               </span>
             </div>
-            <SignOutButton />
+            <div className="flex items-center gap-2">
+              <ThemeToggle />
+              <SignOutButton />
+            </div>
           </div>
         </div>
       </nav>

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { SessionProvider } from "next-auth/react"
+import { ThemeProvider } from "next-themes"
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  )
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <Button variant="outline" size="icon" disabled>
+        <Sun className="h-4 w-4" />
+      </Button>
+    )
+  }
+
+  const isDark = theme === "dark"
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {isDark ? (
+        <Moon className="h-4 w-4" />
+      ) : (
+        <Sun className="h-4 w-4" />
+      )}
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- Added theme switcher toggle with sun/moon icons in dashboard header
- Sun icon for light mode, moon icon for dark mode
- Toggle positioned next to sign out button
- Theme preference persists automatically via next-themes

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)